### PR TITLE
Align Netty dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,25 @@ sourceSets {
   }
 }
 
+ext {
+  netty41Version = '4.1.136.Final'
+  netty42Version = '4.2.16.Final'
+}
+
+allprojects {
+  configurations.configureEach {
+    resolutionStrategy.eachDependency { details ->
+      if (details.requested.group == 'io.netty' && details.requested.version != null) {
+        if (details.requested.version.startsWith('4.2.')) {
+          details.useVersion netty42Version
+        } else if (details.requested.version.startsWith('4.1.')) {
+          details.useVersion netty41Version
+        }
+      }
+    }
+  }
+}
+
 dependencies {
   gatlingImplementation project(':common-performance')
 }
@@ -48,6 +67,8 @@ dependencies {
 dependencyCheck {
   suppressionFile = "common/common-performance/owasp/owasp-suppressions.xml"
   analyzers.assemblyEnabled = false
+  analyzers.ossIndexEnabled = false
+  scanConfigurations = ['runtimeClasspath', 'gatlingRuntimeClasspath']
 }
 
 configurations {


### PR DESCRIPTION
Aligns Netty 4.1.x and 4.2.x dependencies centrally and limits OWASP dependency-check scanning to the relevant runtime configurations.